### PR TITLE
fix Howler#off

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -1237,9 +1237,18 @@
             break;
           }
         }
-      } else {
+      } else if (event) {
         // Clear out all events of this type.
-        self['on' + event] = [];
+        self['_on' + event] = [];
+      } else {
+        // Clear out all events of every type.
+        var keys = Object.keys(self);
+        for (var i=0; i<keys.length; i++) {
+          var key = keys[i];
+          if ((key.indexOf('_on') === 0) && Array.isArray(self[key])) {
+            self[key] = [];
+          }
+        }
       }
 
       return self;


### PR DESCRIPTION
Hi, 

I would like for Howler#off to be able to remove all events attached to the instance when it is called without arguments as it is done in many other event listening systems. Right now one has to call the function repeatedly listing every event name which is a bit tedious and error prone. 

Also, there was a typo in the function's code preventing it from removing all events of a given type.